### PR TITLE
Update gmp to support linux on arm

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -55,11 +55,12 @@ class Gmp < Formula
     # Enable --with-pic to avoid linking issues with the static library
     args << "--with-pic"
 
+    cpu = Hardware::CPU.arm? ? "aarch64" : Hardware.oldest_cpu
+
     if OS.mac?
-      cpu = Hardware::CPU.arm? ? "aarch64" : Hardware.oldest_cpu
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
     else
-      args << "--build=core2-linux-gnu"
+      args << "--build=#{cpu}-linux-gnu"
       args << "ABI=32" if Hardware::CPU.is_32_bit?
     end
 


### PR DESCRIPTION
The recipe presumed that non-mac was running on x86. This correctly this fact to support, at minimum, linux on arm.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
